### PR TITLE
Update quizdlg.ui

### DIFF
--- a/QuizDb/quizdlg.ui
+++ b/QuizDb/quizdlg.ui
@@ -335,7 +335,7 @@
     <string>Highlight Key</string>
    </property>
    <property name="checked">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
This should default the `Highlight key` value to unchecked.